### PR TITLE
fix: StyleX Usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,9 @@
   "devDependencies": {
     "@turbo/gen": "^2.0.4",
     "turbo": "^2.0.4"
+  },
+  "resolutions": {
+    "react": "19.0.0-beta-e7d213dfb0-20240507",
+    "react-dom": "19.0.0-beta-e7d213dfb0-20240507"
   }
 }

--- a/packages/extract-comments/src/package.json
+++ b/packages/extract-comments/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/fwoosh/src/cli/cli.ts
+++ b/packages/fwoosh/src/cli/cli.ts
@@ -3,7 +3,7 @@ import { lilconfig } from "lilconfig";
 const findCacheDirectoryPromise = import("find-cache-dir");
 import { promises as fs } from "fs";
 import path from "path";
-import { consola } from "consola";
+// import { consola } from "consola";
 
 import { FwooshConfig } from "@fwoosh/types";
 
@@ -55,7 +55,7 @@ const fwoosh: MultiCommand = {
 const args = app(fwoosh);
 
 if (args?.error) {
-  consola.error(args.error);
+  console.error(args.error);
   process.exit(1);
 }
 

--- a/packages/fwoosh/src/components/BenchLayout.tsx
+++ b/packages/fwoosh/src/components/BenchLayout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import * as stylex from "@stylexjs/stylex";
 
 import { StoryContext } from "@fwoosh/types";
 import { StoryContextProvider } from "@fwoosh/ui";
@@ -9,14 +10,13 @@ import { ToolsToolbar } from "./ToolsToolbar";
 import { Panels } from "./Panels";
 import { Panel, PanelGroup, PanelResizeHandle } from "./ResizablePanels";
 
-// NAMAN
-// import { gray } from "@fwoosh/ui/colors";
+import { gray } from "@fwoosh/ui/colors.stylex";
 
-// const inspectorStyles = stylex.create({
-//   base: {
-//     backgroundColor: gray.subtleBg,
-//   },
-// });
+const inspectorStyles = stylex.create({
+  base: {
+    backgroundColor: gray.subtleBg,
+  },
+});
 
 export interface BenchLayoutProps extends StoryContext {
   children: ReactNode;

--- a/packages/plugin-react-docgen/package.json
+++ b/packages/plugin-react-docgen/package.json
@@ -41,6 +41,7 @@
   "types": "./dist/commonjs/index.d.ts",
   "type": "module",
   "dependencies": {
+    "@types/node": "^20.14.2",
     "react-docgen-typescript": "^2.2.2"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@fwoosh/config-typescript": "workspace:*",
+    "@types/node": "^20.14.2",
     "rimraf": "^5.0.7",
     "tshy": "^1.15.1"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,7 @@
     "exports": {
       ".": "./src/index.ts",
       "./components": "./src/components/index.ts",
-      "./colors": "./src/theme/colors.stylex.ts",
+      "./colors.stylex": "./src/theme/colors.stylex.ts",
       "./app": "./src/app/app.tsx"
     }
   },
@@ -64,7 +64,7 @@
         "default": "./dist/commonjs/components/index.js"
       }
     },
-    "./colors": {
+    "./colors.stylex": {
       "import": {
         "source": "./src/theme/colors.stylex.ts",
         "types": "./dist/esm/theme/colors.stylex.d.ts",

--- a/packages/ui/src/components/Tabs.tsx
+++ b/packages/ui/src/components/Tabs.tsx
@@ -11,7 +11,8 @@ import {
   TabPanelProps,
 } from "react-aria-components";
 import * as stylex from "@stylexjs/stylex";
-import { gray, space } from "../theme/theme.stylex.js";
+import { space } from "../theme/theme.stylex.js";
+import { gray } from "../theme/colors.stylex.js";
 
 export function Tabs(props: TabsProps) {
   return <TabsPrimitive {...props} />;

--- a/packages/ui/src/theme/theme.stylex.ts
+++ b/packages/ui/src/theme/theme.stylex.ts
@@ -22,5 +22,3 @@ export const space = stylex.defineVars({
   4: "8px",
   5: "16px",
 });
-
-export * from "./colors.stylex.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  react: 19.0.0-beta-e7d213dfb0-20240507
+  react-dom: 19.0.0-beta-e7d213dfb0-20240507
+
 importers:
 
   .:
@@ -76,6 +80,8 @@ importers:
   packages/extract-comments/dist/commonjs: {}
 
   packages/extract-comments/dist/esm: {}
+
+  packages/extract-comments/src: {}
 
   packages/fwoosh:
     dependencies:
@@ -174,10 +180,6 @@ importers:
         specifier: ^0.7.5
         version: 0.7.5
 
-  packages/fwoosh/dist/commonjs: {}
-
-  packages/fwoosh/dist/esm: {}
-
   packages/plugin-description:
     dependencies:
       '@fwoosh/ui':
@@ -206,12 +208,11 @@ importers:
         specifier: ^1.15.1
         version: 1.15.1
 
-  packages/plugin-description/dist/commonjs: {}
-
-  packages/plugin-description/dist/esm: {}
-
   packages/plugin-react-docgen:
     dependencies:
+      '@types/node':
+        specifier: ^20.14.2
+        version: 20.14.2
       react-docgen-typescript:
         specifier: ^2.2.2
         version: 2.2.2(typescript@5.4.5)
@@ -237,10 +238,6 @@ importers:
       tshy:
         specifier: ^1.15.1
         version: 1.15.1
-
-  packages/plugin-react-docgen/dist/commonjs: {}
-
-  packages/plugin-react-docgen/dist/esm: {}
 
   packages/plugin-zoom:
     dependencies:
@@ -276,15 +273,14 @@ importers:
         specifier: ^1.15.1
         version: 1.15.1
 
-  packages/plugin-zoom/dist/commonjs: {}
-
-  packages/plugin-zoom/dist/esm: {}
-
   packages/types:
     devDependencies:
       '@fwoosh/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@types/node':
+        specifier: ^20.14.2
+        version: 20.14.2
       rimraf:
         specifier: ^5.0.7
         version: 5.0.7
@@ -315,10 +311,10 @@ importers:
         version: 0.395.0(react@19.0.0-beta-e7d213dfb0-20240507)
       react-aria:
         specifier: ^3.33.1
-        version: 3.33.1(react@19.0.0-beta-e7d213dfb0-20240507)
+        version: 3.33.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       react-aria-components:
         specifier: ^1.2.1
-        version: 1.2.1(react@19.0.0-beta-e7d213dfb0-20240507)
+        version: 1.2.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
     devDependencies:
       '@fwoosh/config-typescript':
         specifier: workspace:*
@@ -340,7 +336,7 @@ importers:
         version: 19.0.0-beta-e7d213dfb0-20240507
       react-server-dom-webpack:
         specifier: 19.0.0-beta-e7d213dfb0-20240507
-        version: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)(webpack@5.92.0)
+        version: 19.0.0-beta-e7d213dfb0-20240507(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)(webpack@5.92.0)
       rimraf:
         specifier: ^5.0.7
         version: 5.0.7
@@ -350,10 +346,6 @@ importers:
       tsx:
         specifier: ^4.15.5
         version: 4.15.5
-
-  packages/ui/dist/commonjs: {}
-
-  packages/ui/dist/esm: {}
 
 packages:
 
@@ -1128,7 +1120,7 @@ packages:
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1141,7 +1133,7 @@ packages:
   /@radix-ui/react-icons@1.3.0(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==}
     peerDependencies:
-      react: ^16.x || ^17.x || ^18.x
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
@@ -1149,7 +1141,7 @@ packages:
   /@react-aria/breadcrumbs@3.5.13(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-G1Gqf/P6kVdfs94ovwP18fTWuIxadIQgHsXS08JEVcFVYMjb9YjqnEBaohUxD1tq2WldMbYw53ahQblT4NTG+g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/link': 3.7.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1163,7 +1155,7 @@ packages:
   /@react-aria/button@3.9.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-dgcYR6j8WDOMLKuVrtxzx4jIC05cVKDzc+HnPO8lNkBAOfjcuN5tkGRtIjLtqjMvpZHhQT5aDbgFpIaZzxgFIg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1175,11 +1167,11 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/calendar@3.5.8(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/calendar@3.5.8(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-Whlp4CeAA5/ZkzrAHUv73kgIRYjw088eYGSc+cvSOCxfrc/2XkBm9rNrnSBv0DvhJ8AG0Fjz3vYakTmF3BgZBw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1192,12 +1184,13 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/checkbox@3.14.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-EtBJL6iu0gvrw3A4R7UeVLR6diaVk/mh4kFBc7c8hQjpEJweRr4hmJT3hrNg3MBcTWLxFiMEXPGgWEwXDBygtA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/form': 3.0.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1213,17 +1206,17 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/color@3.0.0-beta.33(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/color@3.0.0-beta.33(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-nhqnIHYm5p6MbuF3cC6lnqzG7MjwBsBd0DtpO+ByFYO+zxpMMbeC5R+1SFxvapR4uqmAzTotbtiUCGsG+SUaIg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/numberfield': 3.11.3(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/numberfield': 3.11.3(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/slider': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/spinbutton': 3.6.5(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/spinbutton': 3.6.5(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/textfield': 3.14.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/visually-hidden': 3.8.12(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1233,20 +1226,21 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/combobox@3.9.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/combobox@3.9.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-SpK92dCmT8qn8aEcUAihRQrBb5LZUhwIbDExFII8PvUvEFy/PoQHXIo3j1V29WkutDBDpMvBv/6XRCHGXPqrhQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/listbox': 3.12.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/listbox': 3.12.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/live-announcer': 3.3.4
-      '@react-aria/menu': 3.14.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/overlays': 3.22.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/menu': 3.14.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/overlays': 3.22.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/textfield': 3.14.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1257,13 +1251,14 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/datepicker@3.10.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/datepicker@3.10.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-4HZL593nrNMa1GjBmWEN/OTvNS6d3/16G1YJWlqiUlv11ADulSbqBIjMmkgwrJVFcjrgqtXFy+yyrTA/oq94Zw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@internationalized/number': 3.5.3
@@ -1273,7 +1268,7 @@ packages:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/label': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/spinbutton': 3.6.5(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/spinbutton': 3.6.5(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/datepicker': 3.9.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/form': 3.0.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1284,46 +1279,49 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/dialog@3.5.14(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/dialog@3.5.14(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-oqDCjQ8hxe3GStf48XWBf2CliEnxlR9GgSYPHJPUc69WBj68D9rVcCW3kogJnLAnwIyf3FnzbX4wSjvUa88sAQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/overlays': 3.22.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/overlays': 3.22.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/dialog': 3.5.10(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/dnd@3.6.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/dnd@3.6.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-6WnujUTD+cIYZVF/B+uXdHyJ+WSpbYa8jH282epvY4FUAq1qLmen12/HHcoj/5dswKQe8X6EM3OhkQM89d9vFw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/string': 3.2.3
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/live-announcer': 3.3.4
-      '@react-aria/overlays': 3.22.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/overlays': 3.22.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/dnd': 3.3.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/button': 3.9.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/focus@3.17.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1336,7 +1334,7 @@ packages:
   /@react-aria/form@3.0.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-n290jRwrrRXO3fS82MyWR+OKN7yznVesy5Q10IclSTVYHHI3VI53xtAPr/WzNjJR1um8aLhOcDNFKwnNIUUCsQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1346,17 +1344,17 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/grid@3.9.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/grid@3.9.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-fGEZqAEaS8mqzV/II3N4ndoNWegIcbh+L3PmKbXdpKKUP8VgMs/WY5rYl5WAF0f5RoFwXqx3ibDLeR9tKj/bOg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/live-announcer': 3.3.4
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/grid': 3.8.7(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1367,19 +1365,20 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/gridlist@3.8.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/gridlist@3.8.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-vVPkkA+Ct0NDcpnNm/tnYaBumg0fP9pXxsPLqL1rxvsTyj1PaIpFTZ4corabPTbTDExZwUSTS3LG1n+o1OvBtQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/grid': 3.9.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/grid': 3.9.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/list': 3.10.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1387,12 +1386,13 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/i18n@3.11.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-vuiBHw1kZruNMYeKkTGGnmPyMnM5T+gT8bz97H1FqIq1hQ6OPzmtBZ6W6l6OIMjeHI5oJo4utTwfZl495GALFQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@internationalized/message': 3.1.4
@@ -1408,7 +1408,7 @@ packages:
   /@react-aria/interactions@3.21.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/ssr': 3.9.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1420,7 +1420,7 @@ packages:
   /@react-aria/label@3.7.8(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-MzgTm5+suPA3KX7Ug6ZBK2NX9cin/RFLsv1BdafJ6CZpmUSpWnGE/yQfYUB7csN7j31OsZrD3/P56eShYWAQfg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1431,7 +1431,7 @@ packages:
   /@react-aria/link@3.7.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-a4IaV50P3fXc7DQvEIPYkJJv26JknFbRzFT5MJOMgtzuhyJoQdILEUK6XHYjcSSNCA7uLgzpojArVk5Hz3lCpw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1442,15 +1442,15 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/listbox@3.12.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/listbox@3.12.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-7JiUp0NGykbv/HgSpmTY1wqhuf/RmjFxs1HZcNaTv8A+DlzgJYc7yQqFjP3ZA/z5RvJFuuIxggIYmgIFjaRYdA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/label': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/list': 3.10.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1458,6 +1458,7 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/live-announcer@3.3.4:
@@ -1466,17 +1467,17 @@ packages:
       '@swc/helpers': 0.5.11
     dev: false
 
-  /@react-aria/menu@3.14.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/menu@3.14.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-BYliRb38uAzq05UOFcD5XkjA5foQoXRbcH3ZufBsc4kvh79BcP1PMW6KsXKGJ7dC/PJWUwCui6QL1kUg8PqMHA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/overlays': 3.22.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/overlays': 3.22.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/menu': 3.7.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1486,12 +1487,13 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/meter@3.4.13(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-oG6KvHQM3ri93XkYQkgEaMKSMO9KNDVpcW1MUqFfqyUXHFBRZRrJB4BTXMZ4nyjheFVQjVboU51fRwoLjOzThg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/progress': 3.4.13(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/meter': 3.4.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1500,15 +1502,15 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/numberfield@3.11.3(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/numberfield@3.11.3(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-QQ9ZTzBbRI8d9ksaBWm6YVXbgv+5zzUsdxVxwzJVXLznvivoORB8rpdFJzUEWVCo25lzoBxluCEPYtLOxP1B0w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/spinbutton': 3.6.5(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/spinbutton': 3.6.5(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/textfield': 3.14.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/form': 3.0.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1518,13 +1520,14 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/overlays@3.22.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/overlays@3.22.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-GHiFMWO4EQ6+j6b5QCnNoOYiyx1Gk8ZiwLzzglCI4q1NY5AG2EAmfU4Z1+Gtrf2S5Y0zHbumC7rs9GnPoGLUYg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1538,12 +1541,13 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/progress@3.4.13(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-YBV9bOO5JzKvG8QCI0IAA00o6FczMgIDiK8Q9p5gKorFMatFUdRayxlbIPoYHMi+PguLil0jHgC7eOyaUcrZ0g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/label': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1557,7 +1561,7 @@ packages:
   /@react-aria/radio@3.10.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-3fmoMcQtCpgjTwJReFjnvIE/C7zOZeCeWUn4JKDqz9s1ILYsC3Rk5zZ4q66tFn6v+IQnecrKT52wH6+hlVLwTA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/form': 3.0.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1575,7 +1579,7 @@ packages:
   /@react-aria/searchfield@3.7.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-h1sMUOWjhevaKKUHab/luHbM6yiyeN57L4RxZU0IIc9Ww0h5Rp2GUuKZA3pcdPiExHje0aijcImL3wBHEbKAzw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/textfield': 3.14.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1588,19 +1592,19 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/select@3.14.5(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/select@3.14.5(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-s8jixBuTUNdKWRHe2tIJqp55ORHeUObGMw1s7PQRRVrrHPdNSYseAOI9B2W7qpl3hKhvjJg40UW+45mcb1WKbw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/form': 3.0.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/label': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/listbox': 3.12.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/menu': 3.14.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/listbox': 3.12.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/menu': 3.14.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/visually-hidden': 3.8.12(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/select': 3.6.4(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1609,13 +1613,14 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/selection@3.18.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/selection@3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-GSqN2jX6lh7v+ldqhVjAXDcrWS3N4IsKXxO6L6Ygsye86Q9q9Mq9twWDWWu5IjHD6LoVZLUBCMO+ENGbOkyqeQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1625,12 +1630,13 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/separator@3.3.13(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-hofA6JCPnAOqSE9vxnq7Dkazr7Kb2A0I5sR16fOG7ddjYRc/YEY5Nv7MWfKUGU0kNFHkgNjsDAILERtLechzeA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1641,7 +1647,7 @@ packages:
   /@react-aria/slider@3.7.8(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-MYvPcM0K8jxEJJicUK2+WxUkBIM/mquBxOTOSSIL3CszA80nXIGVnLlCUnQV3LOUzpWtabbWaZokSPtGgOgQOw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1655,11 +1661,11 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/spinbutton@3.6.5(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/spinbutton@3.6.5(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-0aACBarF/Xr/7ixzjVBTQ0NBwwwsoGkf5v6AVFVMTC0uYMXHTALvRs+ULHjHMa5e/cX/aPlEvaVT7jfSs+Xy9Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/live-announcer': 3.3.4
@@ -1668,13 +1674,14 @@ packages:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/ssr@3.9.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==}
     engines: {node: '>= 12'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -1683,7 +1690,7 @@ packages:
   /@react-aria/switch@3.6.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-2nVqz4ZuJyof47IpGSt3oZRmp+EdS8wzeDYgf42WHQXrx4uEOk1mdLJ20+NnsYhj/2NHZsvXVrjBeKMjlMs+0w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/toggle': 3.10.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/toggle': 3.7.4(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1692,14 +1699,14 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/table@3.14.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/table@3.14.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-WaPgQe4zQF5OaluO5rm+Y2nEoFR63vsLd4BT4yjK1uaFhKhDY2Zk+1SCVQvBLLKS4WK9dhP05nrNzT0vp/ZPOw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/grid': 3.9.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/grid': 3.9.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/live-announcer': 3.3.4
@@ -1715,48 +1722,51 @@ packages:
       '@react-types/table': 3.9.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/tabs@3.9.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/tabs@3.9.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-S5v/0sRcOaSXaJYZuuy1ZVzYc7JD4sDyseG1133GjyuNjJOFHgoWMb+b4uxNIJbZxnLgynn/ZDBZSO+qU+fIxw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/tabs': 3.6.6(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/tabs': 3.3.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /@react-aria/tag@3.4.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/tag@3.4.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-gcIGPYZ2OBwMT4IHnlczEezKlxr0KRPL/mSfm2Q91GE027ZGOJnqusH9az6DX1qxrQx8x3vRdqYT2KmuefkrBQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
-      '@react-aria/gridlist': 3.8.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/gridlist': 3.8.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/label': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/list': 3.10.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/button': 3.9.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/textfield@3.14.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-hj7H+66BjB1iTKKaFXwSZBZg88YT+wZboEXZ0DNdQB2ytzoz/g045wBItUuNi4ZjXI3P+0AOZznVMYadWBAmiA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/form': 3.0.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1773,7 +1783,7 @@ packages:
   /@react-aria/toggle@3.10.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-bRk+CdB8QzrSyGNjENXiTWxfzYKRw753iwQXsEAU7agPCUdB8cZJyrhbaUoD0rwczzTp2zDbZ9rRbUPdsBE2YQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1787,7 +1797,7 @@ packages:
   /@react-aria/toolbar@3.0.0-beta.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-c8spY7aeLI6L+ygdXvEbAzaT41vExsxZ1Ld0t7BB+6iEF3nyBNJHshjkgdR7nv8FLgNk0no4tj0GTq4Jj4UqHQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1800,7 +1810,7 @@ packages:
   /@react-aria/tooltip@3.7.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-+XRx4HlLYqWY3fB8Z60bQi/rbWDIGlFUtXYbtoa1J+EyRWfhpvsYImP8qeeNO/vgjUtDy1j9oKa8p6App9mBMQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1812,27 +1822,28 @@ packages:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
 
-  /@react-aria/tree@3.0.0-alpha.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /@react-aria/tree@3.0.0-alpha.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-CucyeJ4VeAvWO5UJHt/l9JO65CVtsOVUctMOVNCQS77Isqp3olX9pvfD3LXt8fD5Ph2g0Q/b7siVpX5ieVB32g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
-      '@react-aria/gridlist': 3.8.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/gridlist': 3.8.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/tree': 3.8.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/button': 3.9.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /@react-aria/utils@3.24.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/ssr': 3.9.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1845,7 +1856,7 @@ packages:
   /@react-aria/visually-hidden@3.8.12(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-Bawm+2Cmw3Xrlr7ARzl2RLtKh0lNUdJ0eNqzWcyx4c0VHUAWtThmH5l+HRqFUGzzutFZVo89SAy40BAbd0gjVw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1857,7 +1868,7 @@ packages:
   /@react-stately/calendar@3.5.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-7l7QhqGUJ5AzWHfvZzbTe3J4t72Ht5BmhW4hlVI7flQXtfrmYkVtl3ZdytEZkkHmWGYZRW9b4IQTQGZxhtlElA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1870,7 +1881,7 @@ packages:
   /@react-stately/checkbox@3.6.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-IXV3f9k+LtmfQLE+DKIN41Q5QB/YBLDCB1YVx5PEdRp52S9+EACD5683rjVm8NVRDwjMi2SP6RnFRk7fVb5Azg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/form': 3.0.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1883,7 +1894,7 @@ packages:
   /@react-stately/collections@3.10.7(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-KRo5O2MWVL8n3aiqb+XR3vP6akmHLhLWYZEmPKjIv0ghQaEebBTrN3wiEjtd6dzllv0QqcWvDLM1LntNfJ2TsA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
@@ -1893,7 +1904,7 @@ packages:
   /@react-stately/color@3.6.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-iW0nAhl3+fUBegHMw5EcAbFVDpgwHBrivfC85pVoTM3pyzp66hqNN6R6xWxW6ETyljS8UOer59+/w4GDVGdPig==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/number': 3.5.3
       '@internationalized/string': 3.2.3
@@ -1911,7 +1922,7 @@ packages:
   /@react-stately/combobox@3.8.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-iLVGvKRRz0TeJXZhZyK783hveHpYA6xovOSdzSD+WGYpiPXo1QrcrNoH3AE0Z2sHtorU+8nc0j58vh5PB+m2AA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/form': 3.0.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1928,7 +1939,7 @@ packages:
   /@react-stately/data@3.11.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-PbnUQxeE6AznSuEWYnRmrYQ9t5z1Asx98Jtrl96EeA6Iapt9kOjTN9ySqCxtPxMKleb1NIqG3+uHU3veIqmLsg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
@@ -1938,7 +1949,7 @@ packages:
   /@react-stately/datepicker@3.9.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-yBdX01jn6gq4NIVvHIqdjBUPo+WN8Bujc4OnPw+ZnfA4jI0eIgq04pfZ84cp1LVXW0IB0VaCu1AlQ/kvtZjfGA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@internationalized/string': 3.2.3
@@ -1954,7 +1965,7 @@ packages:
   /@react-stately/dnd@3.3.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-I/Ci5xB8hSgAXzoWYWScfMM9UK1MX/eTlARBhiSlfudewweOtNJAI+cXJgU7uiUnGjh4B4v3qDBtlAH1dWDCsw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/selection': 3.15.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1971,7 +1982,7 @@ packages:
   /@react-stately/form@3.0.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-92YYBvlHEWUGUpXgIaQ48J50jU9XrxfjYIN8BTvvhBHdD63oWgm8DzQnyT/NIAMzdLnhkg7vP+fjG8LjHeyIAg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@swc/helpers': 0.5.11
@@ -1981,7 +1992,7 @@ packages:
   /@react-stately/grid@3.8.7(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-he3TXCLAhF5C5z1/G4ySzcwyt7PEiWcVIupxebJQqRyFrNWemSuv+7tolnStmG8maMVIyV3P/3j4eRBbdSlOIg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/selection': 3.15.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -1994,7 +2005,7 @@ packages:
   /@react-stately/list@3.10.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-fV9plO+6QDHiewsYIhboxcDhF17GO95xepC5ki0bKXo44gr14g/LSo/BMmsaMnV+1BuGdBunB05bO4QOIaigXA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/selection': 3.15.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2007,7 +2018,7 @@ packages:
   /@react-stately/menu@3.7.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-mX1w9HHzt+xal1WIT2xGrTQsoLvDwuB2R1Er1MBABs//MsJzccycatcgV/J/28m6tO5M9iuFQQvLV+i1dCtodg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/overlays': 3.6.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/menu': 3.9.9(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2019,7 +2030,7 @@ packages:
   /@react-stately/numberfield@3.9.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-UlPTLSabhLEuHtgzM0PgfhtEaHy3yttbzcRb8yHNvGo4KbCHeHpTHd3QghKfTFm024Mug7+mVlWCmMtW0f5ttg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/number': 3.5.3
       '@react-stately/form': 3.0.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2032,7 +2043,7 @@ packages:
   /@react-stately/overlays@3.6.7(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-6zp8v/iNUm6YQap0loaFx6PlvN8C0DgWHNlrlzMtMmNuvjhjR0wYXVaTfNoUZBWj25tlDM81ukXOjpRXg9rLrw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/overlays': 3.8.7(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2043,7 +2054,7 @@ packages:
   /@react-stately/radio@3.10.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-kCIc7tAl4L7Hu4Wt9l2jaa+MzYmAJm0qmC8G8yPMbExpWbLRu6J8Un80GZu+JxvzgDlqDyrVvyv9zFifwH/NkQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/form': 3.0.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2056,7 +2067,7 @@ packages:
   /@react-stately/searchfield@3.5.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-H0OvlgwPIFdc471ypw79MDjz3WXaVq9+THaY6JM4DIohEJNN5Dwei7O9g6r6m/GqPXJIn5TT3b74kJ2Osc00YQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/searchfield': 3.5.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2067,7 +2078,7 @@ packages:
   /@react-stately/select@3.6.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-whZgF1N53D0/dS8tOFdrswB0alsk5Q5620HC3z+5f2Hpi8gwgAZ8TYa+2IcmMYRiT+bxVuvEc/NirU9yPmqGbA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/form': 3.0.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/list': 3.10.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2081,7 +2092,7 @@ packages:
   /@react-stately/selection@3.15.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-6TQnN9L0UY9w19B7xzb1P6mbUVBtW840Cw1SjgNXCB3NPaCf59SwqClYzoj8O2ZFzMe8F/nUJtfU1NS65/OLlw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2093,7 +2104,7 @@ packages:
   /@react-stately/slider@3.5.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-Jsf7K17dr93lkNKL9ij8HUcoM1sPbq8TvmibD6DhrK9If2lje+OOL8y4n4qreUnfMT56HCAeS9wCO3fg3eMyrw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2105,7 +2116,7 @@ packages:
   /@react-stately/table@3.11.8(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-EdyRW3lT1/kAVDp5FkEIi1BQ7tvmD2YgniGdLuW/l9LADo0T+oxZqruv60qpUS6sQap+59Riaxl91ClDxrJnpg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/flags': 3.0.3
@@ -2122,7 +2133,7 @@ packages:
   /@react-stately/tabs@3.6.6(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-sOLxorH2uqjAA+v1ppkMCc2YyjgqvSGeBDgtR/lyPSDd4CVMoTExszROX2dqG0c8il9RQvzFuufUtQWMY6PgSA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/list': 3.10.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2134,7 +2145,7 @@ packages:
   /@react-stately/toggle@3.7.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-CoYFe9WrhLkDP4HGDpJYQKwfiYCRBAeoBQHv+JWl5eyK61S8xSwoHsveYuEZ3bowx71zyCnNAqWRrmNOxJ4CKA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/utils': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/checkbox': 3.8.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2145,7 +2156,7 @@ packages:
   /@react-stately/tooltip@3.4.9(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-P7CDJsdoKarz32qFwf3VNS01lyC+63gXpDZG31pUu+EO5BeQd4WKN/AH1Beuswpr4GWzxzFc1aXQgERFGVzraA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/overlays': 3.6.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/tooltip': 3.4.9(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2156,7 +2167,7 @@ packages:
   /@react-stately/tree@3.8.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-LOdkkruJWch3W89h4B/bXhfr0t0t1aRfEp+IMrrwdRAl23NaPqwl5ILHs4Xu5XDHqqhg8co73pHrJwUyiTWEjw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/collections': 3.10.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/selection': 3.15.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2169,7 +2180,7 @@ packages:
   /@react-stately/utils@3.10.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@swc/helpers': 0.5.11
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2178,7 +2189,7 @@ packages:
   /@react-stately/virtualizer@3.7.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-voHgE6EQ+oZaLv6u2umKxakvIKNkCQuUihqKACTjdslp7SJh4Mvs3oLBI0hf0JOh+rCcFIKDvQtFwy1fXFRYBA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2189,7 +2200,7 @@ packages:
   /@react-types/breadcrumbs@3.7.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-lV9IDYsMiu2TgdMIjEmsOE0YWwjb3jhUNK1DCZZfq6uWuiHLgyx2EncazJBUWSjHJ4ta32j7xTuXch+8Ai6u/A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/link': 3.5.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2199,7 +2210,7 @@ packages:
   /@react-types/button@3.9.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-raeQBJUxBp0axNF74TXB8/H50GY8Q3eV6cEKMbZFP1+Dzr09Ngv0tJBeW0ewAxAguNH5DRoMUAUGIXtSXskVdA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2208,7 +2219,7 @@ packages:
   /@react-types/calendar@3.4.6(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-WSntZPwtvsIYWvBQRAPvuCn55UTJBZroTvX0vQvWykJRQnPAI20G1hMQ3dNsnAL+gLZUYxBXn66vphmjUuSYew==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2218,7 +2229,7 @@ packages:
   /@react-types/checkbox@3.8.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-5/oVByPw4MbR/8QSdHCaalmyWC71H/QGgd4aduTJSaNi825o+v/hsN2/CH7Fq9atkLKsC8fvKD00Bj2VGaKriQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2227,7 +2238,7 @@ packages:
   /@react-types/color@3.0.0-beta.25(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-D24ASvLeSWouBwOBi4ftUe4/BhrZj5AiHV7tXwrVeMGOy9Z9jyeK65Xysq+R3ecaSONLXsgai5CQMvj13cOacA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/slider': 3.7.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2237,7 +2248,7 @@ packages:
   /@react-types/combobox@3.11.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-UNc3OHt5cUt5gCTHqhQIqhaWwKCpaNciD8R7eQazmHiA9fq8ROlV+7l3gdNgdhJbTf5Bu/V5ISnN7Y1xwL3zqQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2246,7 +2257,7 @@ packages:
   /@react-types/datepicker@3.7.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-ZfvgscvNzBJpYyVWg3nstJtA/VlWLwErwSkd1ivZYam859N30w8yH+4qoYLa6FzWLCFlrsRHyvtxlEM7lUAt5A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@react-types/calendar': 3.4.6(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2258,7 +2269,7 @@ packages:
   /@react-types/dialog@3.5.10(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-S9ga+edOLNLZw7/zVOnZdT5T40etpzUYBXEKdFPbxyPYnERvRxJAsC1/ASuBU9fQAXMRgLZzADWV+wJoGS/X9g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/overlays': 3.8.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2268,7 +2279,7 @@ packages:
   /@react-types/form@3.7.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-HZojAWrb6feYnhDEOy3vBamDVAHDl0l2JQZ7aIDLHmeTAGQC3JNZcm2fLTxqLye46zz8w8l8OHgI+NdD4PHdOw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2277,7 +2288,7 @@ packages:
   /@react-types/grid@3.2.6(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-XfHenL2jEBUYrhKiPdeM24mbLRXUn79wVzzMhrNYh24nBwhsPPpxF+gjFddT3Cy8dt6tRInfT6pMEu9nsXwaHw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2286,7 +2297,7 @@ packages:
   /@react-types/link@3.5.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-G6P5WagHDR87npN7sEuC5IIgL1GsoY4WFWKO4734i2CXRYx24G9P0Su3AX4GA3qpspz8sK1AWkaCzBMmvnunfw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2295,7 +2306,7 @@ packages:
   /@react-types/listbox@3.4.9(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-S5G+WmNKUIOPZxZ4svWwWQupP3C6LmVfnf8QQmPDvwYXGzVc0WovkqUWyhhjJirFDswTXRCO9p0yaTHHIlkdwQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2304,7 +2315,7 @@ packages:
   /@react-types/menu@3.9.9(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-FamUaPVs1Fxr4KOMI0YcR2rYZHoN7ypGtgiEiJ11v/tEPjPPGgeKDxii0McCrdOkjheatLN1yd2jmMwYj6hTDg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/overlays': 3.8.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2314,7 +2325,7 @@ packages:
   /@react-types/meter@3.4.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-AIJV4NDFAqKH94s02c5Da4TH2qgJjfrw978zuFM0KUBFD85WRPKh7MvgWpomvUgmzqE6lMCzIdi1KPKqrRabdw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/progress': 3.5.4(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2323,7 +2334,7 @@ packages:
   /@react-types/numberfield@3.8.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-z5fGfVj3oh5bmkw9zDvClA1nDBSFL9affOuyk2qZ/M2SRUmykDAPCksbfcMndft0XULWKbF4s2CYbVI+E/yrUA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2332,7 +2343,7 @@ packages:
   /@react-types/overlays@3.8.7(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-zCOYvI4at2DkhVpviIClJ7bRrLXYhSg3Z3v9xymuPH3mkiuuP/dm8mUCtkyY4UhVeUTHmrQh1bzaOP00A+SSQA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2341,7 +2352,7 @@ packages:
   /@react-types/progress@3.5.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-JNc246sTjasPyx5Dp7/s0rp3Bz4qlu4LrZTulZlxWyb53WgBNL7axc26CCi+I20rWL9+c7JjhrRxnLl/1cLN5g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2350,7 +2361,7 @@ packages:
   /@react-types/radio@3.8.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-bK0gio/qj1+0Ldu/3k/s9BaOZvnnRgvFtL3u5ky479+aLG5qf1CmYed3SKz8ErZ70JkpuCSrSwSCFf0t1IHovw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2359,7 +2370,7 @@ packages:
   /@react-types/searchfield@3.5.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-T/NHg12+w23TxlXMdetogLDUldk1z5dDavzbnjKrLkajLb221bp8brlR/+O6C1CtFpuJGALqYHgTasU1qkQFSA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/textfield': 3.9.3(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2369,7 +2380,7 @@ packages:
   /@react-types/select@3.9.4(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-xI7dnOW2st91fPPcv6hdtrTdcfetYiqZuuVPZ5TRobY7Q10/Zqqe/KqtOw1zFKUj9xqNJe4Ov3xP5GSdcO60Eg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2378,7 +2389,7 @@ packages:
   /@react-types/shared@3.23.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
@@ -2386,7 +2397,7 @@ packages:
   /@react-types/slider@3.7.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-F8qFQaD2mqug2D0XeWMmjGBikiwbdERFlhFzdvNGbypPLz3AZICBKp1ZLPWdl0DMuy03G/jy6Gl4mDobl7RT2g==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2395,7 +2406,7 @@ packages:
   /@react-types/switch@3.5.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-Nb6+J5MrPaFa8ZNFKGMzAsen/NNzl5UG/BbC65SLGPy7O0VDa/sUpn7dcu8V2xRpRwwIN/Oso4v63bt2sgdkgA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2404,7 +2415,7 @@ packages:
   /@react-types/table@3.9.5(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-fgM2j9F/UR4Anmd28CueghCgBwOZoCVyN8fjaIFPd2MN4gCwUUfANwxLav65gZk4BpwUXGoQdsW+X50L3555mg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/grid': 3.2.6(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -2414,7 +2425,7 @@ packages:
   /@react-types/tabs@3.3.7(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-ZdLe5xOcFX6+/ni45Dl2jO0jFATpTnoSqj6kLIS/BYv8oh0n817OjJkLf+DS3CLfNjApJWrHqAk34xNh6nRnEg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2423,7 +2434,7 @@ packages:
   /@react-types/textfield@3.9.3(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-DoAY6cYOL0pJhgNGI1Rosni7g72GAt4OVr2ltEx2S9ARmFZ0DBvdhA9lL2nywcnKMf27PEJcKMXzXc10qaHsJw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
@@ -2432,7 +2443,7 @@ packages:
   /@react-types/tooltip@3.4.9(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-wZ+uF1+Zc43qG+cOJzioBmLUNjRa7ApdcT0LI1VvaYvH5GdfjzUJOorLX9V/vAci0XMJ50UZ+qsh79aUlw2yqg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-types/overlays': 3.8.7(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -4286,7 +4297,7 @@ packages:
   /lucide-react@0.395.0(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-6hzdNH5723A4FLaYZWpK50iyZH8iS2Jq5zuPRRotOFkhu6kxxJiebVdJ72tCR5XkiIeYFOU5NUawFZOac+VeYw==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
@@ -4634,20 +4645,20 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-aria-components@1.2.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /react-aria-components@1.2.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-iGIdDjbTyLLn0/tGUyBQxxu+E1bw4/H4AU89d0cRcu8yIdw6MXG29YElmRHn0ugiyrERrk/YQALihstnns5kRQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/date': 3.5.4
       '@internationalized/string': 3.2.3
-      '@react-aria/color': 3.0.0-beta.33(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/color': 3.0.0-beta.33(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/menu': 3.14.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/menu': 3.14.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/toolbar': 3.0.0-beta.5(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/tree': 3.0.0-alpha.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/tree': 3.0.0-alpha.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/color': 3.6.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/menu': 3.7.1(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -4661,55 +4672,57 @@ packages:
       '@swc/helpers': 0.5.11
       client-only: 0.0.1
       react: 19.0.0-beta-e7d213dfb0-20240507
-      react-aria: 3.33.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      react-aria: 3.33.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
       react-stately: 3.31.1(react@19.0.0-beta-e7d213dfb0-20240507)
       use-sync-external-store: 1.2.2(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
-  /react-aria@3.33.1(react@19.0.0-beta-e7d213dfb0-20240507):
+  /react-aria@3.33.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-hFC3K/UA+90Krlx2IgRTgzFbC6FSPi4pUwHT+STperPLK+cTEHkI+3Lu0YYwQSBatkgxnIv9+GtFuVbps2kROw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@internationalized/string': 3.2.3
       '@react-aria/breadcrumbs': 3.5.13(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/button': 3.9.5(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/calendar': 3.5.8(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/calendar': 3.5.8(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/checkbox': 3.14.3(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/combobox': 3.9.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/datepicker': 3.10.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/dialog': 3.5.14(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/dnd': 3.6.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/combobox': 3.9.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/datepicker': 3.10.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/dialog': 3.5.14(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/dnd': 3.6.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/focus': 3.17.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/gridlist': 3.8.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/gridlist': 3.8.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/i18n': 3.11.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/interactions': 3.21.3(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/label': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/link': 3.7.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/listbox': 3.12.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/menu': 3.14.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/listbox': 3.12.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/menu': 3.14.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/meter': 3.4.13(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/numberfield': 3.11.3(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/overlays': 3.22.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/numberfield': 3.11.3(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/overlays': 3.22.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/progress': 3.4.13(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/radio': 3.10.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/searchfield': 3.7.5(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/select': 3.14.5(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/selection': 3.18.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/select': 3.14.5(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/selection': 3.18.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/separator': 3.3.13(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/slider': 3.7.8(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/ssr': 3.9.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/switch': 3.6.4(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/table': 3.14.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/tabs': 3.9.1(react@19.0.0-beta-e7d213dfb0-20240507)
-      '@react-aria/tag': 3.4.1(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/table': 3.14.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/tabs': 3.9.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
+      '@react-aria/tag': 3.4.1(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/textfield': 3.14.5(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/tooltip': 3.7.4(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/utils': 3.24.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-aria/visually-hidden': 3.8.12(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-types/shared': 3.23.1(react@19.0.0-beta-e7d213dfb0-20240507)
       react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
     dev: false
 
   /react-docgen-typescript@2.2.2(typescript@5.4.5):
@@ -4736,8 +4749,8 @@ packages:
   /react-resizable-panels@2.0.19(react-dom@19.0.0-beta-e7d213dfb0-20240507)(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-v3E41kfKSuCPIvJVb4nL4mIZjjKIn/gh6YqZF/gDfQDolv/8XnhJBek4EiV2gOr3hhc5A3kOGOayk3DhanpaQw==}
     peerDependencies:
-      react: ^16.14.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
+      react-dom: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       react: 19.0.0-beta-e7d213dfb0-20240507
       react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -4755,26 +4768,12 @@ packages:
       neo-async: 2.6.2
       react: 19.0.0-beta-e7d213dfb0-20240507
       react-dom: 19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)
-      webpack: 5.92.0(esbuild@0.21.5)
-
-  /react-server-dom-webpack@19.0.0-beta-e7d213dfb0-20240507(react@19.0.0-beta-e7d213dfb0-20240507)(webpack@5.92.0):
-    resolution: {integrity: sha512-EGhWydDVfrIrvsj+q9UlQ+mGxpXaRj+7XsUz2Zs0Nx2kF9VTDs7xGIpCYQvtO68WYL/hArFtTAVMjOd60seO0Q==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      react: 19.0.0-beta-e7d213dfb0-20240507
-      react-dom: 19.0.0-beta-e7d213dfb0-20240507
-      webpack: ^5.59.0
-    dependencies:
-      acorn-loose: 8.4.0
-      neo-async: 2.6.2
-      react: 19.0.0-beta-e7d213dfb0-20240507
       webpack: 5.92.0
-    dev: true
 
   /react-stately@3.31.1(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-wuq673NHkYSdoceGryjtMJJvB9iQgyDkQDsnTN0t2v91pXjGDsN/EcOvnUrxXSBtY9eLdIw74R54z9GX5cJNEg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       '@react-stately/calendar': 3.5.1(react@19.0.0-beta-e7d213dfb0-20240507)
       '@react-stately/checkbox': 3.6.5(react@19.0.0-beta-e7d213dfb0-20240507)
@@ -5168,30 +5167,6 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  /terser-webpack-plugin@5.3.10(esbuild@0.21.5)(webpack@5.92.0):
-    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      esbuild: 0.21.5
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.31.1
-      webpack: 5.92.0(esbuild@0.21.5)
-
   /terser-webpack-plugin@5.3.10(webpack@5.92.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
@@ -5214,7 +5189,6 @@ packages:
       serialize-javascript: 6.0.2
       terser: 5.31.1
       webpack: 5.92.0
-    dev: true
 
   /terser@5.31.1:
     resolution: {integrity: sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==}
@@ -5477,7 +5451,7 @@ packages:
   /use-sync-external-store@1.2.2(react@19.0.0-beta-e7d213dfb0-20240507):
     resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: 19.0.0-beta-e7d213dfb0-20240507
     dependencies:
       react: 19.0.0-beta-e7d213dfb0-20240507
     dev: false
@@ -5663,46 +5637,6 @@ packages:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(webpack@5.92.0)
-      watchpack: 2.4.1
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: true
-
-  /webpack@5.92.0(esbuild@0.21.5):
-    resolution: {integrity: sha512-Bsw2X39MYIgxouNATyVpCNVWBCuUwDgWtN78g6lSdPJRLaQ/PUVm/oXcaRAyY/sMFoKFQrsPeqvTizWtq7QPCA==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.5
-      '@webassemblyjs/ast': 1.12.1
-      '@webassemblyjs/wasm-edit': 1.12.1
-      '@webassemblyjs/wasm-parser': 1.12.1
-      acorn: 8.12.0
-      acorn-import-attributes: 1.9.5(acorn@8.12.0)
-      browserslist: 4.23.1
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.17.0
-      es-module-lexer: 1.5.3
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.21.5)(webpack@5.92.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
Only use StyleX variables defined with `stylex.defineVars` *directly* as named imports from files where they are defined which should be named `.stylex.ts` and the import should include the `.stylex` suffix as well.